### PR TITLE
chore: use go-gitignore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/raphamorim/notify
 
 go 1.11
 
-require golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7
+require (
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+	golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7 h1:bit1t3mgdR35yN0cX0G8orgLtOuyL9Wqxa1mccLB0ig=
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ignore.go
+++ b/ignore.go
@@ -9,25 +9,22 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sabhiram/go-gitignore"
 )
 
 // IgnoreMatcher provides gitignore-style pattern matching for paths
 type IgnoreMatcher struct {
-	patterns []ignorePattern
-	root     string
-}
-
-type ignorePattern struct {
-	pattern  string
-	isNegate bool
-	isDir    bool
+	patterns  []string
+	gitignore *ignore.GitIgnore
+	root      string
 }
 
 // NewIgnoreMatcher creates a new ignore matcher with the given root directory
 func NewIgnoreMatcher(root string) *IgnoreMatcher {
 	return &IgnoreMatcher{
 		root:     root,
-		patterns: make([]ignorePattern, 0),
+		patterns: make([]string, 0),
 	}
 }
 
@@ -38,45 +35,51 @@ func (im *IgnoreMatcher) AddPattern(pattern string) {
 		return
 	}
 
-	p := ignorePattern{pattern: pattern}
+	im.patterns = append(im.patterns, pattern)
+	im.recompile()
+}
 
-	// Handle negation
-	if strings.HasPrefix(pattern, "!") {
-		p.isNegate = true
-		p.pattern = pattern[1:]
+// recompile rebuilds the gitignore matcher with all current patterns
+func (im *IgnoreMatcher) recompile() {
+	if len(im.patterns) == 0 {
+		im.gitignore = nil
+		return
 	}
-
-	// Handle directory-only patterns
-	if strings.HasSuffix(p.pattern, "/") {
-		p.isDir = true
-		p.pattern = strings.TrimSuffix(p.pattern, "/")
-	}
-
-	im.patterns = append(im.patterns, p)
+	im.gitignore = ignore.CompileIgnoreLines(im.patterns...)
 }
 
 // LoadIgnoreFile loads patterns from a .gitignore or .notifyignore file
 func (im *IgnoreMatcher) LoadIgnoreFile(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil // Ignore file doesn't exist, which is fine
+	}
+
+	// Read the file and add each line as a pattern
 	file, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // Ignore file doesn't exist, which is fine
-		}
 		return err
 	}
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		im.AddPattern(scanner.Text())
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && !strings.HasPrefix(line, "#") {
+			im.patterns = append(im.patterns, line)
+		}
 	}
 
-	return scanner.Err()
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	im.recompile()
+	return nil
 }
 
 // ShouldIgnore returns true if the given path should be ignored
 func (im *IgnoreMatcher) ShouldIgnore(path string) bool {
-	if im == nil || len(im.patterns) == 0 {
+	if im == nil || im.gitignore == nil {
 		return false
 	}
 
@@ -90,149 +93,18 @@ func (im *IgnoreMatcher) ShouldIgnore(path string) bool {
 	relPath = filepath.ToSlash(relPath)
 	relPath = strings.TrimPrefix(relPath, "./")
 
-	// Determine if path is a directory syntactically to avoid FS stat flakiness
-	isDir := strings.HasSuffix(relPath, "/")
-	if !isDir {
-		if fi, err := os.Stat(path); err == nil && fi.IsDir() {
-			isDir = true
-		}
-	}
-
-	ignored := false
-	for _, p := range im.patterns {
-		pat := strings.TrimPrefix(p.pattern, "./")
-
-		// Directory patterns should match the dir itself or anything under it
-		if p.isDir {
-			// Exact dir match
-			if im.matchPattern(pat, relPath) || strings.HasPrefix(relPath+"/", pat+"/") {
-				if p.isNegate {
-					ignored = false
-				} else {
-					ignored = true
-				}
-				continue
-			}
-		}
-
-		// Regular pattern matching (files or generic globs)
-		if im.matchPattern(pat, relPath) {
-			if p.isNegate {
-				ignored = false
-			} else {
-				ignored = true
-			}
-		}
-	}
-
-	return ignored
-}
-
-// matchPattern implements gitignore-style pattern matching
-func (im *IgnoreMatcher) matchPattern(pattern, path string) bool {
-	// Handle patterns starting with /
-	if strings.HasPrefix(pattern, "/") {
-		pattern = pattern[1:]
-		return im.matchGlob(pattern, path)
-	}
-
-	// Check exact match first
-	if im.matchGlob(pattern, path) {
+	// Check if path matches
+	if im.gitignore.MatchesPath(relPath) {
 		return true
 	}
 
-	// Pattern can match at any level
-	parts := strings.Split(path, "/")
-	for i := range parts {
-		subPath := strings.Join(parts[i:], "/")
-		if im.matchGlob(pattern, subPath) {
-			return true
-		}
-		// Also check individual directory names
-		if im.matchGlob(pattern, parts[i]) {
-			return true
-		}
+	// Also check with trailing slash for directory patterns
+	// This handles the case where .git/ should match .git directory
+	if im.gitignore.MatchesPath(relPath + "/") {
+		return true
 	}
 
 	return false
-}
-
-// matchGlob implements basic glob matching
-func (im *IgnoreMatcher) matchGlob(pattern, path string) bool {
-	// Handle ** for recursive matching
-	if strings.Contains(pattern, "**") {
-		return im.matchDoublestar(pattern, path)
-	}
-
-	// Simple glob matching
-	matched, _ := filepath.Match(pattern, path)
-	if matched {
-		return true
-	}
-
-	// Check if pattern matches any parent directory
-	parts := strings.Split(path, "/")
-	for i := range parts {
-		if matched, _ := filepath.Match(pattern, parts[i]); matched {
-			return true
-		}
-	}
-
-	return false
-}
-
-// matchDoublestar handles ** patterns
-func (im *IgnoreMatcher) matchDoublestar(pattern, path string) bool {
-	// Normalize
-	pattern = filepath.ToSlash(pattern)
-	path = filepath.ToSlash(path)
-
-	// Edge case: pattern is just **
-	if strings.Trim(pattern, "/") == "**" {
-		return true
-	}
-
-	// Split pattern by ** and ensure order
-	parts := strings.Split(pattern, "**")
-	// Allow multiple ** by scanning sequentially
-	cur := path
-	leading := strings.TrimSuffix(parts[0], "/")
-	if leading != "" {
-		if !strings.HasPrefix(cur, strings.TrimPrefix(leading, "/")) {
-			return false
-		}
-		cur = strings.TrimPrefix(cur, strings.TrimPrefix(leading, "/"))
-		cur = strings.TrimPrefix(cur, "/")
-	}
-	// For each remaining segment after **, ensure it appears in order
-	for i := 1; i < len(parts); i++ {
-		seg := strings.Trim(parts[i], "/")
-		if seg == "" {
-			continue
-		}
-		// Find seg anywhere in cur boundaries
-		idx := indexGlob(cur, seg)
-		if idx == -1 {
-			return false
-		}
-		cur = cur[idx+len(seg):]
-	}
-	return true
-}
-
-// indexGlob finds the first index where glob seg matches in s (prefix match)
-func indexGlob(s, seg string) int {
-	// Fast path: literal substring
-	if !strings.ContainsAny(seg, "*?[") {
-		return strings.Index(s, seg)
-	}
-	// Try all cut points
-	for i := 0; i <= len(s); i++ {
-		if ok, _ := filepath.Match(seg, s[i:]); ok {
-			return i
-		}
-	}
-	return -1
 }
 
 // DefaultIgnorePatterns returns common patterns that should be ignored by default

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -5,7 +5,6 @@
 package notify
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 
 func TestIgnoreMatcher(t *testing.T) {
 	// Create a temporary directory for testing
-	tmpDir, err := ioutil.TempDir("", "notify-ignore-test")
+	tmpDir, err := os.MkdirTemp("", "notify-ignore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +74,7 @@ func TestIgnoreMatcher(t *testing.T) {
 
 func TestIgnoreWithWatch(t *testing.T) {
 	// Create a temporary directory for testing
-	tmpDir, err := ioutil.TempDir("", "notify-watch-ignore-test")
+	tmpDir, err := os.MkdirTemp("", "notify-watch-ignore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +140,7 @@ create_files:
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(fullPath, []byte("test"), 0644); err != nil {
+		if err := os.WriteFile(fullPath, []byte("test"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		// Small delay between file creations to ensure events are generated
@@ -204,7 +203,7 @@ create_files:
 
 func TestLoadIgnoreFile(t *testing.T) {
 	// Create a temporary directory
-	tmpDir, err := ioutil.TempDir("", "notify-ignorefile-test")
+	tmpDir, err := os.MkdirTemp("", "notify-ignorefile-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +218,7 @@ build/
 node_modules/
 `
 	ignoreFile := filepath.Join(tmpDir, ".notifyignore")
-	if err := ioutil.WriteFile(ignoreFile, []byte(ignoreContent), 0644); err != nil {
+	if err := os.WriteFile(ignoreFile, []byte(ignoreContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -252,7 +251,7 @@ node_modules/
 }
 
 func TestDoublestarPatterns(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notify-doublestar-test")
+	tmpDir, err := os.MkdirTemp("", "notify-doublestar-test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
we use this library in crush to handle gitignore and it handles folders patterns I think a bit better.